### PR TITLE
Fix movie stimulus streaming and aspect ratio

### DIFF
--- a/VStim/SheinIdelsonStims/VS_movie.m
+++ b/VStim/SheinIdelsonStims/VS_movie.m
@@ -1,6 +1,6 @@
 classdef VS_movie < VStim
     properties (SetAccess=public)
-        playAsImgSequence = true;
+        playAsImgSequence = false;
         randomize = false;
         loops = 1;
         skipFrames = 0;
@@ -67,14 +67,15 @@ classdef VS_movie < VStim
                 disp('Simulation mode finished running');
                 return;
             end
+            maxFrameCount=obj.initialFrozenFrames+max(obj.movFrameCount)*obj.loops;
             
-            obj.flip=nan(obj.nTotTrials,obj.initialFrozenFrames+obj.movFrameCount);
-            obj.stim=nan(obj.nTotTrials,obj.initialFrozenFrames+obj.movFrameCount);
-            obj.flipEnd=nan(obj.nTotTrials,obj.initialFrozenFrames+obj.movFrameCount);
-            obj.miss=nan(obj.nTotTrials,obj.initialFrozenFrames+obj.movFrameCount);
+            obj.flip=nan(obj.nTotTrials,maxFrameCount);
+            obj.stim=nan(obj.nTotTrials,maxFrameCount);
+            obj.flipEnd=nan(obj.nTotTrials,maxFrameCount);
+            obj.miss=nan(obj.nTotTrials,maxFrameCount);
             
-            tFrame=( 0 : ((obj.skipFrames+1)*obj.ifi) : (( (obj.skipFrames+1)*obj.ifi)*(obj.initialFrozenFrames+obj.movFrameCount-1)) )';
-            frameIdx=[ones(1,obj.initialFrozenFrames) 1:obj.movFrameCount];
+            tFrame=( 0 : ((obj.skipFrames+1)*obj.ifi) : (( (obj.skipFrames+1)*obj.ifi)*(maxFrameCount-1)) )';
+            frameIdx=[ones(1,obj.initialFrozenFrames) 1:max(obj.movFrameCount)];
             
             save tmpVSFile obj; %temporarily save object in case of a crash
             disp('Session starting');
@@ -89,13 +90,33 @@ classdef VS_movie < VStim
                 
                 frameTTL=true;
                 if ~obj.playAsImgSequence
-                    [droppedframes] = Screen('PlayMovie', obj.movPtr, 1, obj.loops);
+                    frameCounter = 0;
+                    dstRect = obj.getMovieDestinationRect(currMovie,1);
+                    for k=1:obj.loops
+                        Screen('SetMovieTimeIndex', obj.movPtr(currMovie), 0);
+                        Screen('PlayMovie', obj.movPtr(currMovie), 1, 1, 0);
+                        while true
+                            [tex, ~] = Screen('GetMovieImage', obj.PTB_win, obj.movPtr(currMovie), 1);
+                            if tex <= 0
+                                break;
+                            end
+                            frameCounter = frameCounter+1;
+                            Screen('DrawTexture',obj.PTB_win,tex,[],dstRect,obj.rotation);
+                            obj.applyBackgound;
+                            [obj.flip(i,frameCounter),obj.stim(i,frameCounter),obj.flipEnd(i,frameCounter),obj.miss(i,frameCounter)]=Screen('Flip',obj.PTB_win);
+                            Screen('Close',tex);
+                            obj.sendTTL(3,frameTTL);
+                            frameTTL=~frameTTL;
+                        end
+                        Screen('PlayMovie', obj.movPtr(currMovie), 0);
+                    end
                 else
                     for k=1:obj.loops
                         tFrameTmp=tFrame+GetSecs+obj.ifi/2;
-                        for j=frameIdx
+                        currFrameIdx=[ones(1,obj.initialFrozenFrames) 1:obj.movFrameCount(currMovie)];
+                        for j=currFrameIdx
                             % Update display
-                            Screen('DrawTexture',obj.PTB_win,obj.movTex(j,currMovie),[],obj.visualFieldRect,obj.rotation);
+                            Screen('DrawTexture',obj.PTB_win,obj.movTex(j,currMovie),[],obj.getMovieDestinationRect(currMovie,1),obj.rotation);
                             obj.applyBackgound;
                             
                             [obj.flip(i,j),obj.stim(i,j),obj.flipEnd(i,j),obj.miss(i,j)]=Screen('Flip',obj.PTB_win,tFrameTmp(j));
@@ -147,25 +168,43 @@ classdef VS_movie < VStim
                 Screen('Close',obj.movTex);
                 obj.movTex=[];
             end
+            if ~isempty(obj.movPtr)
+                for iMovie=1:numel(obj.movPtr)
+                    if obj.movPtr(iMovie)>0
+                        Screen('CloseMovie',obj.movPtr(iMovie));
+                    end
+                end
+                obj.movPtr=[];
+            end
         end
-        
+
         function obj=CMloadMovie(obj,srcHandle,eventData,hPanel)
             
+            %clear previous textures
+            obj.cleanUp;
+
             for n=1:obj.nVideos
                 [obj.movieFileName, obj.movPathName] = uigetfile('*.*','Choose movie files or series of images named *_F001-*_FXXX','MultiSelect','On');
+                if isequal(obj.movieFileName,0)
+                    disp('No video was chosen! Did not calculate textures');
+                    return;
+                end
                 if iscell(obj.movieFileName)
                     %order images
                     [~,shortNames]=cellfun(@(x) fileparts(x),obj.movieFileName,'UniformOutput',0);
                     [pImg]=cell2mat(cellfun(@(x) str2num(x(end-2:end)),shortNames,'UniformOutput',0));
                     [~,order]=sort(pImg);
                     obj.movieFileName=obj.movieFileName(order);
+                    obj.playAsImgSequence=true;
+                elseif obj.isMovieFile(obj.movieFileName)
+                    obj.playAsImgSequence=false;
                 end
                 
-                obj.calculateVideoTextures;
+                obj.calculateVideoTextures(n);
             end
         end
         
-        function obj=calculateVideoTextures(obj,event,metaProp)
+        function obj=calculateVideoTextures(obj,n,event,metaProp)
             disp(['preparing textures with rotation ' num2str(obj.rotation) ' !!!!']);
             if iscell(obj.movieFileName)
                 nFiles=numel(obj.movieFileName);
@@ -174,32 +213,38 @@ classdef VS_movie < VStim
             end
             
             if nFiles>0
-                %clear previous textures
-                if obj.nVideos==1
-                    obj.cleanUp;
-                end
                 
                 if nFiles>1 %single frame mode
-                    obj.movFrameCount=nFiles;
+                    obj.movFrameCount(n)=nFiles;
                     obj.playAsImgSequence=true;
                     
-                    for i=1:obj.movFrameCount
+                    for i=1:obj.movFrameCount(n)
                         I=imread([obj.movPathName obj.movieFileName{i}]);
                         [M,N,l]=size(I);
                         
                         if obj.showOnFullScreen==1
-                            obj.movTex(i,obj.nVideos)=Screen('MakeTexture', obj.PTB_win,I,obj.rotation);
+                            obj.movTex(i,n)=Screen('MakeTexture', obj.PTB_win,I,obj.rotation);
+                            obj.movWidth(n)=N;
+                            obj.movHeight(n)=M;
                         elseif N>=M
                             cutPixels=round((N-M)/2);
-                            obj.movTex(i,obj.nVideos)=Screen('MakeTexture', obj.PTB_win,I(:,(cutPixels+1):(end-cutPixels),:),obj.rotation);
+                            obj.movTex(i,n)=Screen('MakeTexture', obj.PTB_win,I(:,(cutPixels+1):(end-cutPixels),:),obj.rotation);
+                            obj.movWidth(n)=M;
+                            obj.movHeight(n)=M;
                         else
                             cutPixels=round((M-N)/2);
-                            obj.movTex(i,obj.nVideos)=Screen('MakeTexture', obj.PTB_win,I((cutPixels+1):(end-cutPixels),:,:),obj.rotation);
+                            obj.movTex(i,n)=Screen('MakeTexture', obj.PTB_win,I((cutPixels+1):(end-cutPixels),:,:),obj.rotation);
+                            obj.movWidth(n)=N;
+                            obj.movHeight(n)=N;
                         end
                         
                         fprintf('%d ',i);
                     end
                 else %complete movie mode
+                    if obj.playAsImgSequence && obj.isMovieFile(obj.movieFileName)
+                        disp('Movie files are streamed from disk; not uploading the whole movie to memory.');
+                        obj.playAsImgSequence=false;
+                    end
                     if obj.playAsImgSequence
                         disp('Uploading video to memory...');
                         readerObj=VideoReader([obj.movPathName obj.movieFileName]);
@@ -208,24 +253,24 @@ classdef VS_movie < VStim
                         vid=read(readerObj);
                         [M,N,l,numF]=size(vid);
                         
-                        obj.movFrameCount=floor(numF./frameRatio);
+                        obj.movFrameCount(n)=floor(numF./frameRatio);
                         disp('Calculating single frame textures:');
-                        for i=1:obj.movFrameCount
+                        for i=1:obj.movFrameCount(n)
                             
                             if obj.showOnFullScreen==1
-                                obj.movTex(i,obj.nVideos)=Screen('MakeTexture', obj.PTB_win,squeeze(vid(:,:,:,ceil(i*frameRatio))),obj.rotation);
+                                obj.movTex(i,n)=Screen('MakeTexture', obj.PTB_win,squeeze(vid(:,:,:,ceil(i*frameRatio))),obj.rotation);
                             elseif N>=M
                                 cutPixels=round((N-M)/2);
-                                obj.movTex(i,obj.nVideos)=Screen('MakeTexture', obj.PTB_win,squeeze(vid(:,(cutPixels+1):(end-cutPixels),:,ceil(i*frameRatio))),obj.rotation);
+                                obj.movTex(i,n)=Screen('MakeTexture', obj.PTB_win,squeeze(vid(:,(cutPixels+1):(end-cutPixels),:,ceil(i*frameRatio))),obj.rotation);
                             else
                                 cutPixels=round((M-N)/2);
-                                obj.movTex(i,obj.nVideos)=Screen('MakeTexture', obj.PTB_win,squeeze(vid(:,:,(cutPixels+1):(end-cutPixels),ceil(i*frameRatio))),obj.rotation);
+                                obj.movTex(i,n)=Screen('MakeTexture', obj.PTB_win,squeeze(vid(:,:,(cutPixels+1):(end-cutPixels),ceil(i*frameRatio))),obj.rotation);
                             end
                              fprintf('%d ',i);
                         end
                         delete(readerObj);
                     else
-                        [obj.movPtr,obj.movDuration,obj.movFps,obj.movWidth,obj.movHeight,obj.movFrameCount,obj.movAspectRatio]=...
+                        [obj.movPtr(n),obj.movDuration(n),obj.movFps(n),obj.movWidth(n),obj.movHeight(n),obj.movFrameCount(n),obj.movAspectRatio(n)]=...
                             Screen('OpenMovie',obj.PTB_win,[obj.movPathName obj.movieFileName]);
                     end
                     
@@ -236,6 +281,32 @@ classdef VS_movie < VStim
                 disp('No video was chosen! Did not calculate textures');
             end
             
+        end
+
+        function dstRect=getMovieDestinationRect(obj,nMovie,screenIdx)
+            if nargin<3
+                screenIdx=1;
+            end
+            if obj.showOnFullScreen==1
+                targetRect=obj.rect(screenIdx,:);
+            else
+                targetRect=obj.visualFieldRect(screenIdx,:);
+            end
+            if isempty(obj.movWidth) || isempty(obj.movHeight) || numel(obj.movWidth)<nMovie || obj.movWidth(nMovie)<=0 || obj.movHeight(nMovie)<=0
+                dstRect=targetRect;
+                return;
+            end
+            targetWidth=targetRect(3)-targetRect(1);
+            targetHeight=targetRect(4)-targetRect(2);
+            scale=min(targetWidth/obj.movWidth(nMovie),targetHeight/obj.movHeight(nMovie));
+            drawWidth=round(obj.movWidth(nMovie)*scale);
+            drawHeight=round(obj.movHeight(nMovie)*scale);
+            dstRect=CenterRect([0 0 drawWidth drawHeight],targetRect);
+        end
+
+        function tf=isMovieFile(obj,fileName)
+            [~,~,ext]=fileparts(fileName);
+            tf=ismember(lower(ext),{'.avi','.mp4','.mov','.mpg','.mpeg','.m4v','.wmv','.mj2'});
         end
         
         function obj=CMsaveVideoAsSingleImages(obj,srcHandle,eventData,hPanel)
@@ -248,7 +319,7 @@ classdef VS_movie < VStim
             for j=frameIdx
                 fprintf('%d ',j);
                 % Update display
-                Screen('DrawTexture',obj.PTB_win,obj.movTex(j,1),[],obj.visualFieldRect,obj.rotation);
+                Screen('DrawTexture',obj.PTB_win,obj.movTex(j,1),[],obj.getMovieDestinationRect(1,1),obj.rotation);
                 obj.applyBackgound;
                 
                 Screen('Flip',obj.PTB_win);


### PR DESCRIPTION
This fixes `VS_movie` so regular movie files are streamed through Psychtoolbox instead of being fully decoded into memory with `VideoReader/read`. This avoids extremely large memory usage for long compressed videos.

It also preserves the movie aspect ratio during drawing, so videos are not forced into a square `visualFieldRect` when `showOnFullScreen` is enabled.